### PR TITLE
fix: link when route does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "patrikjak/auth",
     "description": "Simple auth package for laravel apps",
     "keywords": ["laravel", "auth"],
-    "version": "1.3.0",
+    "version": "1.3.1",
     "type": "library",
     "license": "MIT",
     "autoload": {

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -2,9 +2,11 @@
 
 <x-pjauth::layouts.app :title="__('pjauth::pages.titles.login')">
 
-    <x-slot:links>
-        <p>@lang('pjauth::pages.login.no_account') <a href="{{ route('register') }}" class="primary-color">@lang('pjauth::pages.login.register')</a></p>
-    </x-slot:links>
+    @if(config('pjauth.features.register'))
+        <x-slot:links>
+            <p>@lang('pjauth::pages.login.no_account') <a href="{{ route('register') }}" class="primary-color">@lang('pjauth::pages.login.register')</a></p>
+        </x-slot:links>
+    @endif
 
     <x-slot:image>
         <img src="{{ asset('vendor/pjauth/assets/images/illustrations/hello.svg') }}" alt="welcome">


### PR DESCRIPTION
## Description
[//]: # (Add description here)
- when register feature is disabled, do not show route register link on login page